### PR TITLE
DCC 5048 - Incorrect link to donor clinical data documentation in error report

### DIFF
--- a/theme/config/redirects.json
+++ b/theme/config/redirects.json
@@ -42,6 +42,10 @@
     {
       "from": "/icgc-dcc-project-codes",
       "to": "/submission/projects/#project-codes"
+    },
+    {
+      "from": "/donor-clinical-data-guidelines",
+      "to": "/submission/guide/donor-clinical-data-guidelines/"
     }
 
   ]


### PR DESCRIPTION
**redirect.json** was updated to include correct link to the Donor Clinical Data Guidelines
