### PR TITLE
DCC 5200 dictionary viewer layout fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "json-loader": "0.5.4",
     "stylus": "0.54.5",
     "webpack": "1.13.1",
-    "webpack-notifier": "^1.3.2"
+    "webpack-notifier": "^1.3.2",
+    "regex-colorizer":"0.3.1"
   },
   "dependencies": {
     "@icgc/dictionary-viewer": "1.0.6",

--- a/src/styles/dictionary-viewer.styl
+++ b/src/styles/dictionary-viewer.styl
@@ -216,6 +216,7 @@ td:hover .code-zoom-indicator {
 
 .changes-container {
   text-align: right;
+  padding:0px 15px;
   margin-bottom: 2rem;
 }
 

--- a/src/styles/dictionary-viewer.styl
+++ b/src/styles/dictionary-viewer.styl
@@ -1,5 +1,6 @@
-@import 'node_modules/jsondiffpatch/public/formatters-styles/annotated.css'
-@import 'node_modules/jsondiffpatch/public/formatters-styles/html.css'
+@import 'node_modules/@icgc/dictionary-viewer/node_modules/jsondiffpatch/public/formatters-styles/annotated.css'
+@import 'node_modules/@icgc/dictionary-viewer/node_modules/jsondiffpatch/public/formatters-styles/html.css'
+@import 'node_modules/regex-colorizer/themes/nobg.css'
 @import 'node_modules/@icgc/dictionary-viewer/app/styles/dictionary.css'
 
 .graph {

--- a/theme/js/icgc-common.js
+++ b/theme/js/icgc-common.js
@@ -475,12 +475,21 @@ $(function() {
     _initDisableScrollWhenFooterInView();
     
     // scroll to deep-linked element
-    if (window.location.hash) {
-      document.querySelector('.main-container').scrollTop = document.querySelector(window.location.hash).offsetTop;
+    try {
+      if (window.location.hash) {
+        document.querySelector('.main-container').scrollTop = document.querySelector(window.location.hash).offsetTop;
+      }
+    } catch(e) {
+      console.log(e);
     }
 
     // Hightlight code
     hljs.initHighlightingOnLoad();
+
+    // Preventing sub-menu parents from reloading the page
+    $('.dropdown-submenu > a').click(function(event){
+      event.preventDefault();
+    });
 
   }
 


### PR DESCRIPTION
- regex-colonizer added for CSS
- deep-link JS error fix by wrapping the code around with `try` and `catch` block
- Preventing sub-menu items' parent from reloading the page with user click
- CSS fixes
