### PR TITLE
Fix/dccdocs 56 broken links

### DIFF
--- a/docs/portal/publication.md
+++ b/docs/portal/publication.md
@@ -118,14 +118,14 @@ Data users should freely analyze pre-publication data and act responsibly in pub
 [22]: https://dcc.icgc.org/projects/PAEN-AU
 [23]: https://dcc.icgc.org/projects/SKCA-BR
 [24]: https://dcc.icgc.org/projects/RECA-CN
-[25]: https://dcc.icgc.org/projects/
+[25]: https://dcc.icgc.org/projects/ESCA-CN
 [26]: https://dcc.icgc.org/projects/COCA-CN
 [27]: https://dcc.icgc.org/projects/LUSC-CN
 [28]: https://dcc.icgc.org/projects/RECA-EU
 [29]: https://dcc.icgc.org/projects/LIAD-FR
 [30]: https://dcc.icgc.org/projects/BOCA-FR
 [31]: https://dcc.icgc.org/projects/LIHM-FR
-[32]: https://dcc.icgc.org/projects/PACA-IT
+[32]: https://dcc.icgc.org/projects/PAEN-IT
 [33]: https://dcc.icgc.org/projects/THCA-SA
 [34]: https://dcc.icgc.org/projects/ESAD-UK
 [35]: https://icgc.org/icgc/cgp-template-letters

--- a/docs/software/code.md
+++ b/docs/software/code.md
@@ -25,7 +25,7 @@ as docker containers for provisioning software on docker hosts.
 
 [Storage System GitHub repository](https://github.com/icgc-dcc/dcc-storage)
 
-Software for uploading and downloading ICGC files in cloud environments. This system powers [ICGC in the Cloud](/cloud/about/).
+Software for uploading and downloading ICGC files in cloud environments. This system powers ICGC in the Cloud hosted at [Collaboratory](../../download/repositories/#collaboratory) and [AWS](../../download/repositories/#aws).
 
 ### Submission System (`dcc-submission`)
 

--- a/docs/submission/guide/overview/submitting-raw-data-ega.md
+++ b/docs/submission/guide/overview/submitting-raw-data-ega.md
@@ -278,7 +278,7 @@ NOTE: The sample ID specified in the SAMPLE alias field MUST match the DCC-submi
 [4]: http://docs.icgc.org/dictionary/viewer/#?q=analyzed_sample_id&viewMode=details&dataType=sample
 [5]: http://docs.icgc.org/dictionary/viewer/#?q=donor_sex&viewMode=codelist&dataType=donor
 [6]: http://docs.icgc.org/submission/projects/
-[7]: https://ega-archive.org/quickguide 
+[7]: https://ega-archive.org/submission/quickguide 
 [8]: https://ega-archive.org/submission/sequence/programmatic_submissions/prepare_xml
 [9]: https://ega-archive.org/submission/sequence/metadata
 [10]: https://ega-archive.org/submission/array_based/metadata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_name: ICGC DCC Docs
 site_url: http://docs.icgc.org
 repo_url: https://github.com/icgc-dcc/dcc-docs
 copyright: "&copy; 2015-2016"
+google_analytics: ['UA-43425408-2', 'mkdocs.org']
 theme_dir: theme
 pages:
 - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_name: ICGC DCC Docs
 site_url: http://docs.icgc.org
 repo_url: https://github.com/icgc-dcc/dcc-docs
 copyright: "&copy; 2015-2016"
-google_analytics: ['UA-43425408-2', 'mkdocs.org']
+google_analytics: ['UA-43425408-2', 'docs.icgc.org']
 theme_dir: theme
 pages:
 - Home: index.md


### PR DESCRIPTION
Fixed multiple broken links on DCC-DOCS and added Google Analytics tracking tag, for Issue #56 